### PR TITLE
fix: added uri to context for all created pages

### DIFF
--- a/lib/templates-routes.js
+++ b/lib/templates-routes.js
@@ -63,6 +63,7 @@ module.exports = (api, options) => {
             context: {
               id: entry.id,
               slug: entry.slug,
+              uri: entry.uri,
               section: {
                 // id: section.id,
                 handle: sectionHandle
@@ -150,6 +151,7 @@ module.exports = (api, options) => {
               context: {
                 id: entry.id,
                 slug: entry.slug,
+                uri: entry.uri,
               }
             })
           })


### PR DESCRIPTION
Added the entry URI to the page context for created pages, which is occasionally useful (SEOmatic queries require it for the time being).